### PR TITLE
docs: add README badges for npm, CI, coverage (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![license](https://img.shields.io/npm/l/http-code-responses)](https://github.com/iamgerwin/http-code-responses#license)
 [![CI](https://github.com/iamgerwin/http-code-responses/actions/workflows/ci.yml/badge.svg)](https://github.com/iamgerwin/http-code-responses/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/iamgerwin/http-code-responses/branch/main/graph/badge.svg)](https://codecov.io/gh/iamgerwin/http-code-responses)
+![types](https://img.shields.io/npm/types/http-code-responses)
+![bundle size](https://img.shields.io/bundlephobia/minzip/http-code-responses)
+![node](https://img.shields.io/node/v/http-code-responses)
 
 Readable HTTP status code constants with reason phrases and helpers.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # http-code-responses
 
+[![npm version](https://img.shields.io/npm/v/http-code-responses)](https://www.npmjs.com/package/http-code-responses)
+[![npm downloads](https://img.shields.io/npm/dm/http-code-responses)](https://www.npmjs.com/package/http-code-responses)
+[![license](https://img.shields.io/npm/l/http-code-responses)](https://github.com/iamgerwin/http-code-responses#license)
+[![CI](https://github.com/iamgerwin/http-code-responses/actions/workflows/ci.yml/badge.svg)](https://github.com/iamgerwin/http-code-responses/actions/workflows/ci.yml)
+[![coverage](https://codecov.io/gh/iamgerwin/http-code-responses/branch/main/graph/badge.svg)](https://codecov.io/gh/iamgerwin/http-code-responses)
+
 Readable HTTP status code constants with reason phrases and helpers.
 
 - Concise constants for every standard HTTP status code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**http-code-responses**
+# http-code-responses
 
 Readable HTTP status code constants with reason phrases and helpers.
 
@@ -61,4 +61,3 @@ Notes
 License
 
 - You can set the license of your choice before publishing (the `license` field in `package.json` is intentionally blank).
-


### PR DESCRIPTION
This PR addresses #1 by improving README visibility and project health at a glance.\n\nChanges\n- Use proper H1 title for the README\n- Add core badges: npm version, monthly downloads, license, CI status, coverage (Codecov)\n- Add optional badges: TypeScript types, bundle size (min+gzip), Node version support\n\nNotes\n- CI badge points to the actual workflow file: `.github/workflows/ci.yml`\n- License badge links to the README "License" section to avoid creating an opinionated license file in this PR\n\nScreenshot: badges render under the main title as requested.